### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Not sure what to put here? Check out "PR description contents" in https://replit.com/@util/handbook#eng/ship.md -->
+
+# Why
+
+# What changed
+
+# Test plan
+
+# Pre-flight
+<!-- 
+  - Take a second to consider https://replit.com/@util/handbook#eng/ship.md and add an emoji, a dope meme, a micromanager command (try @replit/micromanager imagegen something cool).
+  - Describe any unusual procedures or requirements needed to roll this out safely, e.g. are there any dashboards that should be monitored for performance or errors 
+-->
+
+
+# Revertibility
+<!--
+  - If necessary, check the below box. If you're not sure, say that!
+  - Make sure to say what special steps or considerations are needed (or indicate it is impossible to rollback).
+  - If it definitely is non-revertible, please clearly indicate that in #ops when it ships 
+-->
+- [ ] This change requires special steps or considerations if it needs to be reverted. 
+


### PR DESCRIPTION
# Why

This PR introduces a pull request template to streamline the PR creation process and ensure that all necessary information is included.

# What changed

A new `.github/pull_request_template.md` file has been created with sections for explaining the purpose of the PR, the changes made, the test plan, and revertibility considerations.

# Test plan

- Verify that the pull request template appears when creating a new PR.
- Ensure that the template prompts for all the required information.